### PR TITLE
Add a trigger for vagrant halt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+
+install:
+  - gem install puppet-lint
+
+script:
+  - puppet-lint --fail-on-warnings --no-2sp_soft_tabs-check --no-hard_tabs-check --no-names_containing_dash-check --no-autoloader_layout-check --no-nested_classes_or_defines-check modules
+
+notifications:
+  slack:
+    secure: JbcRVXdj9FyVH6kbM0tSYi41+5AfChF4AcN76ibUAMQspqp5xna+cdqXxQiLzG9uzgX4dT/vy1QpTI6pJYtru6N3NhX5lMkfDT2gQr9/h5oHjqv/WStPuCXjsUQIS55MnOcNwNjIwyq6PfiFuX5Zn99YdogCa7mdkgQ5TggujBAexZkXUhnXLdZ+/GsLnUeUkdjeIBHDoYrh+/WYeJ94Fmf9vsgEmP6LULnGwqt4n+tLFkqWS9/q6jirbctl+SlN/UdVuuecozvDAkpm5qB52oEjcZTm7IIjrRGq8Hc8xWNYAxOjKjk56trYRZGYgeo87lYcQ+YHtqb82IZNKD3EuHLtbz1nw/jmEsWEv4nBzoKos/9RXw+9Hzm7NFrooqJwX5ThbdjJNQEsnqloXyehKiOpIznf6OnHoOdFLZQfFiOhyUj3RPrQoCKNE9iTLgLb9QE3NljQZW5GBmvAawj1bEF3xymxBS98JZc8d65kLG3q9iwn06MP2RnD2SOlGLl9ECmNLWB4Hcb3AfGUAMKqaZX/rWmT71NvBvVjBTWZSsYQ4JyIMzpFkxi746ODZzxyk6nR8VbtQtHbC3qZAtS5jQANi56p/eiKyXe3OyDtzmaLyxGbe0hbMb2RpcTXSkn5u/oxd26HFGcuELzKQvC9ygPeo0xl+Y82dQ9+MmbTb+c=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install:
   - gem install puppet-lint
 
 script:
-  - puppet-lint --fail-on-warnings --no-2sp_soft_tabs-check --no-hard_tabs-check --no-names_containing_dash-check --no-autoloader_layout-check --no-nested_classes_or_defines-check modules
+  - puppet-lint --fail-on-warnings --no-2sp_soft_tabs-check --no-hard_tabs-check --no-names_containing_dash-check --no-autoloader_layout-check --no-nested_classes_or_defines-check modules chassis.pp
 
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -40,3 +40,12 @@ $ vagrant up
 ==> default: Notice: /Stage[main]/Db-backup/Exec[wordpress-import]/returns: executed successfully
 [...]
 ```
+
+## Configuration
+
+You can optionally have a backup made when you run `vagrant halt` and `vagrant suspend`. To do this you can add the following into your yaml file.
+```
+db-backup:
+    halt: yes
+    suspend: yes
+```

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -13,5 +13,15 @@ module DBBackup
 
 			hook.prepend builder
 		end
+
+		action_hook(:trigger, :machine_action_halt ) do |hook|
+			builder = Builder.new.tap do |b|
+				b.use Builtin::Call, BackupConfirm do |env, b2|
+					DBBackup.backup(env[:machine]) if env[:result]
+				end
+			end
+
+			hook.prepend builder
+		end
 	end
 end

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -3,6 +3,7 @@ module DBBackup
 		name "MySQL Import"
 
 		include Vagrant::Action
+		include Chassis
 
 		action_hook(:trigger, :machine_action_destroy) do |hook|
 			builder = Builder.new.tap do |b|
@@ -14,14 +15,30 @@ module DBBackup
 			hook.prepend builder
 		end
 
-		action_hook(:trigger, :machine_action_halt ) do |hook|
-			builder = Builder.new.tap do |b|
-				b.use Builtin::Call, BackupConfirm do |env, b2|
-					DBBackup.backup(env[:machine]) if env[:result]
-				end
-			end
+		config = Chassis::load_config
 
-			hook.prepend builder
+		if config['db-backup']['halt']
+			action_hook(:trigger, :machine_action_halt ) do |hook|
+				builder = Builder.new.tap do |b|
+					b.use Builtin::Call, BackupConfirm do |env, b2|
+						DBBackup.backup(env[:machine]) if env[:result]
+					end
+				end
+
+				hook.prepend builder
+			end
+		end
+
+		if config['db-backup']['suspend']
+			action_hook(:trigger, :machine_action_suspend ) do |hook|
+				builder = Builder.new.tap do |b|
+					b.use Builtin::Call, BackupConfirm do |env, b2|
+						DBBackup.backup(env[:machine]) if env[:result]
+					end
+				end
+
+				hook.prepend builder
+			end
 		end
 	end
 end

--- a/modules/db-backup/manifests/init.pp
+++ b/modules/db-backup/manifests/init.pp
@@ -11,6 +11,6 @@ class db-backup (
 		onlyif      => "/usr/bin/test -f ${file}",
 		unless      => "/usr/bin/mysql -e 'DESCRIBE sz_posts' ${name} > /dev/null",
 		require     => Mysql::Db[$name],
-		before      => Wp::Site["${wpdir}"]
+		before      => Wp::Site[$wpdir]
 	}
 }

--- a/modules/db-backup/manifests/init.pp
+++ b/modules/db-backup/manifests/init.pp
@@ -7,7 +7,7 @@ class db-backup (
 	exec { "${name}-import":
 		command     => "/usr/bin/mysql ${name} < ${file}",
 		logoutput   => true,
-		environment => "HOME=${root_home}",
+		environment => "HOME=${::root_home}",
 		onlyif      => "/usr/bin/test -f ${file}",
 		unless      => "/usr/bin/mysql -e 'DESCRIBE sz_posts' ${name} > /dev/null",
 		require     => Mysql::Db[$name],

--- a/modules/db-backup/manifests/init.pp
+++ b/modules/db-backup/manifests/init.pp
@@ -1,3 +1,4 @@
+# Create our backup class.
 class db-backup (
 	$file,
 	$name,


### PR DESCRIPTION
This adds support for prompting for a backup when you run `vagrant halt`.

To restore the last backup a user will need to run `vagrant up` and `vagrant provision`.

See #2 for the the idea of adding support for `vagrant halt`