### PR TITLE
Test correct table name so that DB will not import every provision

### DIFF
--- a/modules/db_backup/manifests/init.pp
+++ b/modules/db_backup/manifests/init.pp
@@ -9,7 +9,7 @@ class db_backup (
 		logoutput   => true,
 		environment => "HOME=${::root_home}",
 		onlyif      => "/usr/bin/test -f ${file}",
-		unless      => "/usr/bin/mysql -e 'DESCRIBE ${prefix}_posts' ${name} > /dev/null",
+		unless      => "/usr/bin/mysql -e 'DESCRIBE ${prefix}posts' ${name} > /dev/null",
 		require     => Mysql::Db[$name],
 		before      => Wp::Site[$wpdir]
 	}


### PR DESCRIPTION
prefix will be for example "wp_", with underscore, so prefix_posts will match wp__posts and not wp_posts. Since wp__posts will not exist, the "unless" clause is never satisfied and the DB is currently imported on every provision cycle.